### PR TITLE
Update do_migration() method to run DB migration

### DIFF
--- a/controllers/Matches.php
+++ b/controllers/Matches.php
@@ -314,7 +314,8 @@ class Matches extends CI_Controller {
 
 	public function do_migration()
 	{
-		echo 'test';
+		$this->load->library('migration');
+		$this->migration->current();
 	}
 
 	public function create_migration($action, $table = NULL)


### PR DESCRIPTION
`do_migration()` method migrates DB to `migration_version` number in `application/config/migration.php`.
