### PR TITLE
[Migrations] Add an option to inherit the table name

### DIFF
--- a/controllers/Matches.php
+++ b/controllers/Matches.php
@@ -530,10 +530,19 @@ class Matches extends CI_Controller {
 
                 $this->_find_replace['{{MI_EXTENDS}}'] = $extends;
                 $table = 'SET_YOUR_TABLE_HERE';
+                
                 if(array_key_exists('table',$arguments))
                 {
-                    $table = $arguments['table'];
+                    if($arguments['table'] == '%inherit%')
+                    {
+                        $table = $action;
+                    }
+                    else
+                    {
+                        $table = $arguments['table'];
+                    }
                 }
+                
                 $this->_find_replace['{{TABLE}}'] = $table;
                 $f = strtr($f,$this->_find_replace);
                 if(write_file($migration_path.$file_name.'.php',$f))

--- a/controllers/Matches.php
+++ b/controllers/Matches.php
@@ -535,7 +535,7 @@ class Matches extends CI_Controller {
                 {
                     if($arguments['table'] == '%inherit%')
                     {
-                        $table = preg_replace('/rename.|remove.|modify.|delete.|add.|.table|.tbl/gi', '', $action);
+                        $table = preg_replace('/rename_|remove_|modify_|delete_|add_|_table|_tbl/gi', '', $action);
                     }
                     else
                     {

--- a/controllers/Matches.php
+++ b/controllers/Matches.php
@@ -535,7 +535,7 @@ class Matches extends CI_Controller {
                 {
                     if($arguments['table'] == '%inherit%')
                     {
-                        $table = preg_replace('/rename.|remove.|modify.|delete.|add.|.table|.tbl/i', '', $action);
+                        $table = preg_replace('/rename.|remove.|modify.|delete.|add.|.table|.tbl/gi', '', $action);
                     }
                     else
                     {

--- a/controllers/Matches.php
+++ b/controllers/Matches.php
@@ -535,7 +535,7 @@ class Matches extends CI_Controller {
                 {
                     if($arguments['table'] == '%inherit%')
                     {
-                        $table = $action;
+                        $table = preg_replace('/rename.|remove.|modify.|delete.|add.|.table|.tbl/i', '', $action);
                     }
                     else
                     {


### PR DESCRIPTION
This PR adds the possibility to inherit the table name from the migration name.

It also strips these parts from the migration name:
```
rename_
remove_
modify_
delete_
add_
_table
_tbl
```

You use the new feature like this:
```shell
# Notice: The table name would be my_awesome_buddies
php index.php matches create:migration t:%inherit% add_my_awesome_buddies_table
```